### PR TITLE
Add zlib to the list of dependencies for Debian/Ubuntu hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Install dependencies -
  Debian/Ubuntu hosts:
 
 ```sh
- $ sudo apt-get install build-essential autoconf automake libtool
+ $ sudo apt-get install build-essential autoconf automake libtool zlib1g-dev
 ```
 
  Fedora/RedHat/CentOS hosts:


### PR DESCRIPTION
Updated the install dependencies for Debian/Ubuntu hosts with missing
zlib as the missing dependency would make compilation fail.