### PR TITLE
Fix off-by-one error potentially causing stray write

### DIFF
--- a/src/erasurecode_preprocessing.c
+++ b/src/erasurecode_preprocessing.c
@@ -247,7 +247,7 @@ int get_fragment_partition(
      */ 
     for (i = 0; i < num_fragments; i++) {
         index = get_fragment_idx(fragments[i]);
-        if (index < 0 || index > (k + m)) {
+        if (index < 0 || index >= (k + m)) {
             return -EBADHEADER;
         }
         if (index < k) {


### PR DESCRIPTION
Properly check that index is within k+m fragments. Otherwise a fragment with a wrong index can cause a stray write.